### PR TITLE
Add actionlint workflow job to validate GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1
+
   install:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary
This change adds a new `actionlint` job to the CI/CD pipeline to automatically validate GitHub Actions workflow files for syntax errors and best practices.

## Key Changes
- Added a new `actionlint` job that runs on `ubuntu-24.04`
- Integrated `reviewdog/action-actionlint@v1` to lint all workflow files in the repository
- The job runs on both push and pull request events alongside existing test jobs

## Implementation Details
The actionlint job uses the `reviewdog/action-actionlint` action which automatically detects and reports issues in GitHub Actions workflow YAML files. This helps catch configuration errors early and ensures workflow files follow best practices before they are merged.

https://claude.ai/code/session_01DqaDhvZgKQkLkgSk5E2zET